### PR TITLE
Feature/valet share use tls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 composer.lock
 error.log
+.idea/

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -139,6 +139,25 @@ $app->command('secure [domain]', function ($domain = null) {
 })->descriptions('Secure the given domain with a trusted TLS certificate');
 
 /**
+ * Check if a given domain has a trusted TLS certificate.
+ */
+$app->command('secured [domain]', function ($domain = null) {
+    if (!$domain) {
+        warning('Try the following syntax command: valet secured [domain]');
+    }
+
+    $domains = Site::secured();
+
+    foreach ($domains as $item) {
+        $host = explode('.', $item)[0];
+
+        if ($domain && $host === $domain) {
+            info('The ['.$item.'] site has been secured with a TLS certificate.');
+        }
+    }
+})->descriptions('List all secured domain with a trusted TLS certificate');
+
+/**
  * Stop serving the given domain over HTTPS and remove the trusted TLS certificate.
  */
 $app->command('unsecure [domain]', function ($domain = null) {

--- a/valet
+++ b/valet
@@ -44,9 +44,24 @@ then
         fi
     done
 
+    COMMAND=$(php "$DIR/cli/valet.php" secured $HOST)
+    NAME="$HOST.$DOMAIN"
+    KEY_FILE="$HOME/.valet/Certificates/$NAME.key"
+    CRT_FILE="$HOME/.valet/Certificates/$NAME.crt"
+
+    if [ -n "$COMMAND" ]; then
+        echo "$(tput setaf 3)To use TLS tunnels: ngrok authtoken <YOUR_PRO_AUTHTOKEN>"
+        echo "To disable TLS tunnels: valet unsecure ${HOST}$(tput sgr0)"
+
+        COMMAND="tls -crt $CRT_FILE -hostname $NAME -key $KEY_FILE 80"
+    else
+        COMMAND="http $NAME:80 -host-header=rewrite ${*:2}"
+    fi
+
     # Fetch Ngrok URL In Background...
     bash "$DIR/cli/scripts/fetch-share-url.sh" &
-    sudo -u $(logname) "$DIR/bin/ngrok" http "$HOST.$DOMAIN:80" -host-header=rewrite ${*:2}
+    sudo -u $(logname) "$DIR/bin/ngrok" $COMMAND
+
     exit
 
 # Finally, for every other command we will just proxy into the PHP tool


### PR DESCRIPTION
Enable use of ngrok TLS when the `valet share` is run over a TLS secured link.
