### PR TITLE
Fix valet share over TLS secure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 composer.lock
 error.log
+.idea/

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -139,6 +139,25 @@ $app->command('secure [domain]', function ($domain = null) {
 })->descriptions('Secure the given domain with a trusted TLS certificate');
 
 /**
+ * Check if a given domain has a trusted TLS certificate.
+ */
+$app->command('secured [domain]', function ($domain = null) {
+    if (!$domain) {
+        warning('Try the following syntax command: valet secured [domain]');
+    }
+
+    $domains = Site::secured();
+
+    foreach ($domains as $item) {
+        $host = explode('.', $item)[0];
+
+        if ($domain && $host === $domain) {
+            info('The ['.$item.'] site has been secured with a TLS certificate.');
+        }
+    }
+})->descriptions('List all secured domain with a trusted TLS certificate');
+
+/**
  * Stop serving the given domain over HTTPS and remove the trusted TLS certificate.
  */
 $app->command('unsecure [domain]', function ($domain = null) {

--- a/valet
+++ b/valet
@@ -44,9 +44,21 @@ then
         fi
     done
 
+    COMMAND=$(php "$DIR/cli/valet.php" secured $HOST)
+
+    if [ -n "$COMMAND" ]; then
+        HOST="valet.$HOST"
+        echo $(php "$DIR/cli/valet.php" link $HOST)
+    fi
+
     # Fetch Ngrok URL In Background...
     bash "$DIR/cli/scripts/fetch-share-url.sh" &
     sudo -u $(logname) "$DIR/bin/ngrok" http "$HOST.$DOMAIN:80" -host-header=rewrite ${*:2}
+
+    if [ -n "$COMMAND" ]; then
+        echo $(php "$DIR/cli/valet.php" unlink $HOST)
+    fi
+
     exit
 
 # Finally, for every other command we will just proxy into the PHP tool


### PR DESCRIPTION
Now when we have a link secured over TLS the command `valet share` will create other link for an unsecure link and this unsecure link will be used for ngrok.

When the ngrok url is closed that unsecure link is destroyed again. 
